### PR TITLE
fix: #19 タスク削除時のlocalStorage即時更新

### DIFF
--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -123,8 +123,19 @@ export const useTasks = () => {
     return updatedTaskResult;
   }, []);
 
-  const deleteTask = useCallback((id: string): void => {
-    setTasks(prevTasks => prevTasks.filter(task => task.id !== id));
+  const deleteTask = useCallback((id: string) => {
+    setTasks(prevTasks => {
+      const updatedTasks = prevTasks.filter(task => task.id !== id);
+      try {
+        // タスク削除時に即座にlocalStorageを更新
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedTasks));
+        // setError(null); // setError は useEffect に任せるか、別途管理
+      } catch (err) {
+        console.error('Failed to save tasks to localStorage after delete:', err);
+        // setError('Failed to save tasks after deletion.'); // 同上
+      }
+      return updatedTasks;
+    });
   }, []);
 
   const changeTaskStatus = useCallback((id: string, status: TaskStatus): InternalTask | null => {


### PR DESCRIPTION
Issue #19 の修正です。

## 変更点

- `src/hooks/useTasks.ts` の `deleteTask` 関数を修正しました。
- タスク削除時に `localStorage` へ変更が即座に永続化されるようにしました。

## 修正理由

従来の実装では、タスク削除時の状態更新と `localStorage` への永続化の間に非同期性があり、タイミングによっては削除したはずのタスクが新規タスク作成時に復活する問題が発生していました。
今回の修正により、削除操作が即座に `localStorage` に反映されるため、この問題が解決されます。

ご確認よろしくお願いいたします。