### PR TITLE
fix: #20 新規タスクの即時反映とコメント機能の改善

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,11 @@ function App() {
     setSortCriteria,
     deleteTask,
     changeTaskStatus,
+    addTask,
+    updateTask,
+    addCommentToTask,
+    updateTaskComment,
+    deleteTaskComment,
   } = useTasks();
   const [isAddModalVisible, setIsAddModalVisible] = useState(false);
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
@@ -50,18 +55,6 @@ function App() {
 
   const handleStatusChange = (taskId: string, status: TaskStatus) => {
     changeTaskStatus(taskId, status);
-  };
-
-  const handleModalTaskUpdate = (updatedTask: InternalTask | Task | null) => {
-    if (updatedTask) {
-      if ('createdAt' in updatedTask && typeof updatedTask.createdAt !== 'string') {
-        setSelectedTask(toAppTask(updatedTask as InternalTask));
-      } else {
-        setSelectedTask(updatedTask as Task);
-      }
-    } else {
-      setSelectedTask(undefined);
-    }
   };
 
   return (
@@ -95,7 +88,10 @@ function App() {
           <TaskModal
             visible={isAddModalVisible}
             onDismiss={() => setIsAddModalVisible(false)}
-            onTaskUpdate={handleModalTaskUpdate}
+            onAddTask={addTask}
+            onAddComment={addCommentToTask}
+            onUpdateComment={updateTaskComment}
+            onDeleteComment={deleteTaskComment}
           />
 
           {/* タスク編集モーダル */}
@@ -106,7 +102,10 @@ function App() {
               setSelectedTask(undefined);
             }}
             task={selectedTask}
-            onTaskUpdate={handleModalTaskUpdate}
+            onUpdateTask={updateTask}
+            onAddComment={addCommentToTask}
+            onUpdateComment={updateTaskComment}
+            onDeleteComment={deleteTaskComment}
           />
         </ContentLayout>
       }

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -81,7 +81,7 @@ export const useTasks = () => {
   }, [tasks, loading]);
 
   // --- CRUD Operations ---
-  const addTask = useCallback((taskData: TaskFormData): InternalTask => {
+  const addTask = useCallback((taskData: TaskFormData): Promise<InternalTask | null> => {
     const now = new Date();
     const newTask: InternalTask = {
       id: uuidv4(),
@@ -93,13 +93,13 @@ export const useTasks = () => {
       createdAt: now,
       updatedAt: now,
       projectId: taskData.projectId,
-      comments: [], // Initialize comments as an empty array
+      comments: [], 
     };
     setTasks(prevTasks => [...prevTasks, newTask]);
-    return newTask;
+    return Promise.resolve(newTask);
   }, []);
 
-  const updateTask = useCallback((id: string, taskData: Partial<TaskFormData>): InternalTask | null => {
+  const updateTask = useCallback((id: string, taskData: Partial<TaskFormData>): Promise<InternalTask | null> => {
     let updatedTaskResult: InternalTask | null = null;
     setTasks(prevTasks =>
       prevTasks.map(task => {
@@ -120,10 +120,10 @@ export const useTasks = () => {
         return task;
       })
     );
-    return updatedTaskResult;
+    return Promise.resolve(updatedTaskResult);
   }, []);
 
-  const deleteTask = useCallback((id: string) => {
+  const deleteTask = useCallback((id: string): Promise<void> => {
     setTasks(prevTasks => {
       const updatedTasks = prevTasks.filter(task => task.id !== id);
       try {
@@ -136,18 +136,19 @@ export const useTasks = () => {
       }
       return updatedTasks;
     });
+    return Promise.resolve();
   }, []);
 
-  const changeTaskStatus = useCallback((id: string, status: TaskStatus): InternalTask | null => {
+  const changeTaskStatus = useCallback((id: string, status: TaskStatus): Promise<InternalTask | null> => {
     return updateTask(id, { status });
   }, [updateTask]);
 
   // --- Comment Operations ---
-  const addCommentToTask = useCallback(async (taskId: string, commentContent: string): Promise<InternalTask | null> => {
+  const addCommentToTask = useCallback((taskId: string, commentContent: string): Promise<InternalTask | null> => {
     const taskIndex = tasks.findIndex(t => t.id === taskId);
     if (taskIndex === -1) {
       console.error(`[useTasks.ts] addCommentToTask: Task with id ${taskId} not found`);
-      return null; 
+      return Promise.resolve(null); 
     }
     const originalTask = tasks[taskIndex];
 
@@ -181,14 +182,14 @@ export const useTasks = () => {
       return newTasks;
     });
 
-    return updatedTaskInstance; 
+    return Promise.resolve(updatedTaskInstance); 
   }, [tasks]);
 
-  const updateTaskComment = useCallback(async (taskId: string, commentId: string, newContent: string): Promise<InternalTask | null> => {
+  const updateTaskComment = useCallback((taskId: string, commentId: string, newContent: string): Promise<InternalTask | null> => {
     const taskIndex = tasks.findIndex(t => t.id === taskId);
     if (taskIndex === -1) {
       console.error(`[useTasks.ts] updateTaskComment: Task with id ${taskId} not found`);
-      return null;
+      return Promise.resolve(null);
     }
     const originalTask = tasks[taskIndex];
     console.log('[useTasks.ts] updateTaskComment - originalTask.comments:', JSON.stringify(originalTask.comments, null, 2));
@@ -221,14 +222,14 @@ export const useTasks = () => {
       return newTasks;
     });
 
-    return updatedTaskInstance;
+    return Promise.resolve(updatedTaskInstance);
   }, [tasks]);
 
-  const deleteTaskComment = useCallback(async (taskId: string, commentId: string): Promise<InternalTask | null> => {
+  const deleteTaskComment = useCallback((taskId: string, commentId: string): Promise<InternalTask | null> => {
     const taskIndex = tasks.findIndex(t => t.id === taskId);
     if (taskIndex === -1) {
       console.error(`[useTasks.ts] deleteTaskComment: Task with id ${taskId} not found`);
-      return null;
+      return Promise.resolve(null);
     }
     const originalTask = tasks[taskIndex];
     const updatedComments = (originalTask.comments || []).filter(comment => comment.id !== commentId);
@@ -251,7 +252,7 @@ export const useTasks = () => {
       return newTasks;
     });
 
-    return updatedTaskInstance;
+    return Promise.resolve(updatedTaskInstance);
   }, [tasks]);
 
   // --- Filtering and Sorting Logic ---

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -1,4 +1,5 @@
 import { Comment } from './Comment';
+export type { Comment };
 
 /**
  * Represents the status of a task.


### PR DESCRIPTION
Issue #20 の修正です。

変更点：
- TaskModalが自身のuseTasksフックを持たず、タスクの追加・更新・コメント関連処理をAppコンポーネントから渡された関数経由で行うように変更しました。
- これにより、タスクの状態管理が一元化され、タスクやコメントの変更が即座に画面に反映されるようになりました。
- useTasksフック内の各操作関数がPromiseを返すように統一しました。