### PR TITLE
Fix: App.tsx および Task.ts における型エラーの修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,8 @@ import {
 import '@cloudscape-design/global-styles/index.css';
 import { BrowserRouter, Routes, Route } from 'react-router-dom'; 
 import { useTasks, InternalTask, FilterCriteria, SortCriteria } from './hooks/useTasks'; 
-import { Task, TaskFormData, Project, TaskStatus, Comment } from './models/Task'; 
+import { Task, TaskFormData, Project, TaskStatus } from './models/Task'; 
+import { Comment as ProjectComment } from './models/Comment'; 
 import TaskList from './components/TaskList';
 import TaskModal from './components/TaskModal'; 
 import { ProjectList } from './components/ProjectList';
@@ -102,14 +103,14 @@ function App() {
   if (tasksError || projectsError) return <Alert statusIconAriaLabel="Error" type="error">{tasksError || projectsError}</Alert>;
 
   const tasksForTaskList: Task[] = tasks.map((internalTask: InternalTask): Task => {
-    const commentsForTask: Comment[] | undefined = internalTask.comments;
+    const commentsForTask: ProjectComment[] | undefined = internalTask.comments;
 
     return {
       ...internalTask,
       createdAt: internalTask.createdAt.toISOString(),
       updatedAt: internalTask.updatedAt.toISOString(),
       dueDate: internalTask.dueDate?.toISOString(),
-      comments: commentsForTask,
+      comments: commentsForTask, 
     };
   });
 

--- a/src/models/Task.ts
+++ b/src/models/Task.ts
@@ -2,8 +2,6 @@ import { Comment as TaskCommentModel } from './Comment'; // エイリアスを T
 
 export type { TaskCommentModel }; // TaskCommentModel をエクスポート
 
-export type { Comment }; // Comment 型を再エクスポート
-
 export type TaskStatus = 'todo' | 'in-progress' | 'done' | 'inbox' | 'wait-on';
 export type TaskPriority = 'low' | 'medium' | 'high';
 


### PR DESCRIPTION
TypeScript の型エラーを修正しました。

- `src/App.tsx`:
    - DOM の `Comment` 型との衝突を避けるため、プロジェクトのコメント型 (`src/models/Comment.ts` 由来) を `ProjectComment` というエイリアスでインポートし、型注釈を修正しました。
    - `src/models/Task.ts` から存在しない `Comment` 型をインポートしようとしていた箇所を削除しました。
- `src/models/Task.ts`:
    - `Comment` 型の不要な再エクスポートを削除し、TS2661 エラーを解消しました。

これにより、アプリケーションの型安全性が向上します。