### PR TITLE
feat: Inboxタスクとのクリック連携でGTDフローを開始する機能を追加 (#53)

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -28,12 +28,20 @@ const TaskCard: React.FC<TaskCardProps> = ({
 }) => {
   const getStatusIndicator = (status: Task['status']) => {
     switch (status) {
+      case 'inbox':
+        return <StatusIndicator type="info">受信箱</StatusIndicator>;
       case 'todo':
         return <StatusIndicator type="pending">未着手</StatusIndicator>;
       case 'in-progress':
         return <StatusIndicator type="in-progress">進行中</StatusIndicator>;
       case 'done':
         return <StatusIndicator type="success">完了</StatusIndicator>;
+      case 'wait-on':
+        return <StatusIndicator type="warning">待機中</StatusIndicator>;
+      case 'someday-maybe':
+        return <StatusIndicator type="stopped">いつかやるリスト</StatusIndicator>;
+      case 'reference':
+        return <StatusIndicator type="info">参照資料</StatusIndicator>;
       default:
         return <StatusIndicator type="stopped">不明</StatusIndicator>;
     }
@@ -63,6 +71,8 @@ const TaskCard: React.FC<TaskCardProps> = ({
 
   const getNextStatus = (currentStatus: Task['status']): Task['status'] => {
     switch (currentStatus) {
+      case 'inbox':
+        return 'todo'; // インボックスからは未着手へ
       case 'todo':
         return 'in-progress';
       case 'in-progress':
@@ -79,15 +89,52 @@ const TaskCard: React.FC<TaskCardProps> = ({
     onStatusChange(task.id, nextStatus);
   };
 
+  // inboxステータスのタスクをクリックしたときのハンドラ
+  const handleCardClick = () => {
+    if (task.status === 'inbox') {
+      onOpenGtdFlow(task.id);
+    }
+  };
+
+  // inboxステータスのタスクの場合、カードにホバー効果を追加するためのスタイル
+  const divStyle = task.status === 'inbox' ? {
+    cursor: 'pointer',
+    transition: 'all 0.2s ease',
+    ':hover': {
+      backgroundColor: '#f0f0f0',
+      boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
+    }
+  } : {};
+
   return (
+    <div 
+      onClick={task.status === 'inbox' ? handleCardClick : undefined}
+      style={task.status === 'inbox' ? {cursor: 'pointer'} : undefined}
+    >
     <Container
       header={
         <Header
           actions={
             <SpaceBetween direction="horizontal" size="xs">
-              <Button onClick={() => onOpenGtdFlow(task.id)} variant="normal" iconName="external">GTD</Button>
-              <Button onClick={() => onEdit(task)} variant="icon" iconName="edit" />
-              <Button onClick={() => onDelete(task.id)} variant="icon" iconName="remove" />
+              {task.status === 'inbox' ? (
+                <Button onClick={(e) => {
+                  e.stopPropagation(); // カード全体のクリックイベントが発火しないようにする
+                  onOpenGtdFlow(task.id);
+                }} variant="primary" iconName="external">GTD処理</Button>
+              ) : (
+                <Button onClick={(e) => {
+                  e.stopPropagation(); // カード全体のクリックイベントが発火しないようにする
+                  onOpenGtdFlow(task.id);
+                }} variant="normal" iconName="external">GTD</Button>
+              )}
+              <Button onClick={(e) => {
+                e.stopPropagation(); // カード全体のクリックイベントが発火しないようにする
+                onEdit(task);
+              }} variant="icon" iconName="edit" />
+              <Button onClick={(e) => {
+                e.stopPropagation(); // カード全体のクリックイベントが発火しないようにする
+                onDelete(task.id);
+              }} variant="icon" iconName="remove" />
             </SpaceBetween>
           }
         >
@@ -108,13 +155,25 @@ const TaskCard: React.FC<TaskCardProps> = ({
           <Box>作成: {formatDate(new Date(task.createdAt))}</Box>
         </SpaceBetween>
         
-        <Button onClick={handleStatusChange}>
-          {task.status === 'todo' ? '進行中にする' : 
-           task.status === 'in-progress' ? '完了にする' : 
-           '未着手に戻す'}
-        </Button>
+        {task.status !== 'inbox' && (
+          <Button onClick={(e) => {
+            e.stopPropagation(); // カード全体のクリックイベントが発火しないようにする
+            handleStatusChange();
+          }}>
+            {task.status === 'todo' ? '進行中にする' : 
+             task.status === 'in-progress' ? '完了にする' : 
+             '未着手に戻す'}
+          </Button>
+        )}
+        
+        {task.status === 'inbox' && (
+          <Box color="text-status-info" fontWeight="bold">
+            クリックしてGTD処理を開始
+          </Box>
+        )}
       </SpaceBetween>
     </Container>
+    </div>
   );
 };
 


### PR DESCRIPTION
### タスク概要
Issue #53「InboxページとGtdFlowModal.tsxの連携」を実装しました。

### 実装内容
- TaskCard.tsxを修正し、Inboxステータスのタスクに対して以下の機能を追加:
  - タスクカード全体をクリック可能にし、クリックするとGTDフローを開始する
  - 「GTD処理」ボタンをプライマリーボタンに変更して目立たせる
  - 「クリックしてGTD処理を開始」というテキストを追加してユーザーに操作方法を明示
  - ステータスインジケーターを追加し、「受信箱」として表示するように変更
- 各種ステータスのインジケーター表示を改善（wait-on, someday-maybe, referenceなど）

### 関連Issue
- #53 タスク5: InboxとGtdFlowModal.tsxの連携 (Issue #48 下位タスク)

### 動作確認方法
1. アプリケーションを起動
2. 「受信箱」ステータスのタスクを確認
3. タスクカード全体をクリックするか、「GTD処理」ボタンをクリックしてGTDフローが開始されることを確認