### PR TITLE
Issue #54 関連リストUIの調整 - GTDフロー対応の専用ページ追加

### DIFF
--- a/documents/design.md
+++ b/documents/design.md
@@ -122,7 +122,7 @@ interface Task {
   id: string; // 一意の識別子
   title: string; // タスクのタイトル
   description: string; // タスクの詳細説明
-  status: 'inbox' | 'todo' | 'in-progress' | 'done' | 'wait-on'; // タスクのステータス
+  status: 'inbox' | 'todo' | 'in-progress' | 'done' | 'wait-on' | 'someday-maybe' | 'reference'; // タスクのステータス
   priority: 'low' | 'medium' | 'high'; // タスクの優先度
   dueDate?: string; // 期限日 (ISO 8601 format, オプション)
   createdAt: string; // 作成日時 (ISO 8601 format)
@@ -347,6 +347,10 @@ interface Project {
 -   アプリケーション全体のナビゲーションは、`src/App.tsx` 内で Cloudscape Design System の `AppLayout` コンポーネントと `SideNavigation` コンポーネントを使用して実現されています。
 -   画面左側にサイドナビゲーションパネルが表示され、以下の主要ページへのリンクが提供されます:
     -   タスク一覧 (`/`)
+    -   インボックス (`/inbox`)
+    -   待機中タスク (`/waiting-on`)
+    -   いつかやるリスト (`/someday-maybe`)
+    -   資料リスト (`/reference`)
     -   プロジェクト一覧 (`/projects`)
     -   プロジェクト詳細 (`/projects/:projectId`)
 -   `react-router-dom` を利用してクライアントサイドルーティングを行い、ページ遷移を実現しています。
@@ -362,3 +366,14 @@ interface Project {
 -   一覧表示コンポーネント (`TaskList.tsx`, `ProjectList.tsx`) は、対応するカスタムフックからデータを取得し、テーブル形式で表示します。
 -   作成・編集操作は、モーダルウィンドウ (`TaskModal.tsx`, `ProjectModal.tsx`) 内のフォームコンポーネント (`TaskForm.tsx`, `ProjectForm.tsx`) を通じて行われます。
 -   フォーム送信時には、対応するカスタムフックの関数（例: `addTask`, `updateProject`）が呼び出され、データが更新されます。
+-   GTDフロー処理は、`GtdFlowModal.tsx` コンポーネントを通じて行われ、ユーザーの選択に応じてタスクのステータスや属性が更新されます。
+
+### 5.4. GTDフロー関連ページ
+
+-   GTDフローの導入により、新しいステータス値 (`'someday-maybe'`, `'reference'`) に対応する専用ページが追加されました。
+-   各ステータス専用のページコンポーネント:
+    -   `InboxListPage.tsx`: インボックス内のタスクを表示・管理するページ (`/inbox`)
+    -   `WaitingOnListPage.tsx`: 待機中（他者からの返信待ちなど）のタスクを表示・管理するページ (`/waiting-on`)
+    -   `SomedayMaybeListPage.tsx`: 「いつかやる/多分やる」タスクを表示・管理するページ (`/someday-maybe`)
+    -   `ReferenceListPage.tsx`: 参照資料として保存されたタスクを表示・管理するページ (`/reference`)
+-   各ページは、対応するステータスでフィルタリングされたタスクリストを表示し、タスクの編集・削除・ステータス変更機能を提供します。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,10 @@ import { ProjectList } from './components/ProjectList';
 import { AddTaskButton } from './components/AddTaskButton'; 
 import { useProjects } from './hooks/useProjects';
 import ProjectDetailPage from './pages/ProjectDetailPage';
+import InboxListPage from './pages/InboxListPage';
+import WaitingOnListPage from './pages/WaitingOnListPage';
+import SomedayMaybeListPage from './pages/SomedayMaybeListPage';
+import ReferenceListPage from './pages/ReferenceListPage';
 
 const NavigationWrapper: React.FC = () => {
   const navigate = useNavigate();
@@ -47,6 +51,10 @@ const NavigationWrapper: React.FC = () => {
           }}
           items={[
             { type: 'link', text: 'タスク一覧', href: '/' },
+            { type: 'link', text: 'インボックス', href: '/inbox' },
+            { type: 'link', text: '待機中タスク', href: '/waiting-on' },
+            { type: 'link', text: 'いつかやるリスト', href: '/someday-maybe' },
+            { type: 'link', text: '資料リスト', href: '/reference' },
             { type: 'link', text: 'プロジェクト一覧', href: '/projects' },
           ]}
         />
@@ -191,6 +199,10 @@ const AppContent: React.FC = () => {
           </SpaceBetween>
         </ContentLayout>
       } />
+      <Route path="/inbox" element={<InboxListPage />} />
+      <Route path="/waiting-on" element={<WaitingOnListPage />} />
+      <Route path="/someday-maybe" element={<SomedayMaybeListPage />} />
+      <Route path="/reference" element={<ReferenceListPage />} />
       <Route path="/projects" element={<ProjectList />} />
       <Route path="/projects/:projectId" element={<ProjectDetailPage />} />
     </Routes>

--- a/src/pages/InboxListPage.tsx
+++ b/src/pages/InboxListPage.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useMemo } from 'react';
+import {
+  ContentLayout,
+  Header,
+  SpaceBetween,
+  Alert,
+  Spinner,
+} from '@cloudscape-design/components';
+import TaskList from '../components/TaskList';
+import { useTasks, FilterCriteria, SortCriteria, InternalTask } from '../hooks/useTasks';
+import { Comment as ProjectComment } from '../models/Comment';
+import { Task, TaskStatus } from '../models/Task';
+import TaskModal from '../components/TaskModal';
+import { useProjects } from '../hooks/useProjects';
+import { AddTaskButton } from '../components/AddTaskButton';
+
+/**
+ * インボックスページコンポーネント
+ * 
+ * 'inbox'ステータスのタスクを表示するための専用ページです。
+ * GTDメソッドの「収集」フェーズに対応し、未処理のタスクやアイデアを一時的に保管します。
+ */
+const InboxListPage: React.FC = () => {
+  const {
+    tasks,
+    loading: tasksLoading,
+    error: tasksError,
+    updateTask,
+    deleteTask,
+    addTask,
+    filterCriteria,
+    setFilterCriteria,
+    sortCriteria,
+    setSortCriteria,
+    changeTaskStatus,
+  } = useTasks();
+
+  const { projects, loading: projectsLoading } = useProjects();
+
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+  const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  // コンポーネントマウント時に'inbox'フィルターを適用
+  React.useEffect(() => {
+    setFilterCriteria({ ...filterCriteria, status: 'inbox' });
+  }, []);
+
+  const handleOpenCreateModal = () => {
+    setSelectedTask(null);
+    setIsCreateModalVisible(true);
+  };
+
+  const handleEditTask = (task: Task) => {
+    setSelectedTask(task);
+    setIsEditModalVisible(true);
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    if (window.confirm('このタスクを削除してもよろしいですか？')) {
+      await deleteTask(taskId);
+    }
+  };
+
+  const handleStatusChange = async (taskId: string, status: TaskStatus) => {
+    await changeTaskStatus(taskId, status);
+  };
+
+  const handleUpdateExistingTask = async (id: string, formData: any) => {
+    const updatedTask = await updateTask(id, formData);
+    setIsEditModalVisible(false);
+    setSelectedTask(null);
+    return updatedTask;
+  };
+
+  const handleAddNewTask = async (formData: any) => {
+    // インボックスに追加する場合はステータスを強制的に'inbox'に設定
+    const taskData = { ...formData, status: 'inbox' };
+    const newTask = await addTask(taskData);
+    setIsCreateModalVisible(false);
+    return newTask;
+  };
+
+  if (tasksLoading || projectsLoading) {
+    return (
+      <ContentLayout>
+        <Spinner size="large" />
+      </ContentLayout>
+    );
+  }
+
+  if (tasksError) {
+    return (
+      <ContentLayout>
+        <Alert type="error">{tasksError}</Alert>
+      </ContentLayout>
+    );
+  }
+
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return tasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [tasks]);
+
+  return (
+    <ContentLayout header={<Header variant="h1">インボックス</Header>}>
+      <SpaceBetween size="l">
+        <AddTaskButton onClick={handleOpenCreateModal} />
+        <TaskList
+          tasks={tasksForTaskList}
+          loading={tasksLoading}
+          error={tasksError}
+          filterCriteria={filterCriteria as FilterCriteria}
+          setFilterCriteria={setFilterCriteria}
+          sortCriteria={sortCriteria as SortCriteria | null}
+          setSortCriteria={setSortCriteria}
+          onEditTask={handleEditTask}
+          onDeleteTask={handleDeleteTask}
+          onStatusChange={handleStatusChange}
+        />
+        {(isEditModalVisible || isCreateModalVisible) && (
+          <TaskModal
+            visible={isEditModalVisible || isCreateModalVisible}
+            onDismiss={() => {
+              setIsEditModalVisible(false);
+              setIsCreateModalVisible(false);
+              setSelectedTask(null);
+            }}
+            task={selectedTask || undefined}
+            onUpdateTask={handleUpdateExistingTask}
+            onAddTask={handleAddNewTask}
+            projects={projects}
+          />
+        )}
+      </SpaceBetween>
+    </ContentLayout>
+  );
+};
+
+export default InboxListPage;

--- a/src/pages/ReferenceListPage.tsx
+++ b/src/pages/ReferenceListPage.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useMemo } from 'react';
+import {
+  ContentLayout,
+  Header,
+  SpaceBetween,
+  Alert,
+  Spinner,
+} from '@cloudscape-design/components';
+import TaskList from '../components/TaskList';
+import { useTasks, FilterCriteria, SortCriteria, InternalTask } from '../hooks/useTasks';
+import { Comment as ProjectComment } from '../models/Comment';
+import { Task, TaskStatus } from '../models/Task';
+import TaskModal from '../components/TaskModal';
+import { useProjects } from '../hooks/useProjects';
+
+/**
+ * 資料リストページコンポーネント
+ * 
+ * 'reference'ステータスのタスクを表示するための専用ページです。
+ */
+const ReferenceListPage: React.FC = () => {
+  const {
+    tasks,
+    loading: tasksLoading,
+    error: tasksError,
+    updateTask,
+    deleteTask,
+    filterCriteria,
+    setFilterCriteria,
+    sortCriteria,
+    setSortCriteria,
+    changeTaskStatus,
+  } = useTasks();
+
+  const { projects, loading: projectsLoading } = useProjects();
+
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  // コンポーネントマウント時に'reference'フィルターを適用
+  React.useEffect(() => {
+    setFilterCriteria({ ...filterCriteria, status: 'reference' });
+  }, []);
+
+  const handleEditTask = (task: Task) => {
+    setSelectedTask(task);
+    setIsEditModalVisible(true);
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    if (window.confirm('このタスクを削除してもよろしいですか？')) {
+      await deleteTask(taskId);
+    }
+  };
+
+  const handleStatusChange = async (taskId: string, status: TaskStatus) => {
+    await changeTaskStatus(taskId, status);
+  };
+
+  const handleUpdateExistingTask = async (id: string, formData: any) => {
+    const updatedTask = await updateTask(id, formData);
+    setIsEditModalVisible(false);
+    setSelectedTask(null);
+    return updatedTask;
+  };
+
+  if (tasksLoading || projectsLoading) {
+    return (
+      <ContentLayout>
+        <Spinner size="large" />
+      </ContentLayout>
+    );
+  }
+
+  if (tasksError) {
+    return (
+      <ContentLayout>
+        <Alert type="error">{tasksError}</Alert>
+      </ContentLayout>
+    );
+  }
+
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return tasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [tasks]);
+
+  return (
+    <ContentLayout header={<Header variant="h1">資料リスト</Header>}>
+      <SpaceBetween size="l">
+        <TaskList
+          tasks={tasksForTaskList}
+          loading={tasksLoading}
+          error={tasksError}
+          filterCriteria={filterCriteria as FilterCriteria}
+          setFilterCriteria={setFilterCriteria}
+          sortCriteria={sortCriteria as SortCriteria | null}
+          setSortCriteria={setSortCriteria}
+          onEditTask={handleEditTask}
+          onDeleteTask={handleDeleteTask}
+          onStatusChange={handleStatusChange}
+        />
+        {isEditModalVisible && selectedTask && (
+          <TaskModal
+            visible={isEditModalVisible}
+            onDismiss={() => {
+              setIsEditModalVisible(false);
+              setSelectedTask(null);
+            }}
+            task={selectedTask}
+            onUpdateTask={handleUpdateExistingTask}
+            onAddTask={() => Promise.resolve(null)}
+            projects={projects}
+          />
+        )}
+      </SpaceBetween>
+    </ContentLayout>
+  );
+};
+
+export default ReferenceListPage;

--- a/src/pages/SomedayMaybeListPage.tsx
+++ b/src/pages/SomedayMaybeListPage.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useMemo } from 'react';
+import {
+  ContentLayout,
+  Header,
+  SpaceBetween,
+  Alert,
+  Spinner,
+} from '@cloudscape-design/components';
+import TaskList from '../components/TaskList';
+import { useTasks, FilterCriteria, SortCriteria, InternalTask } from '../hooks/useTasks';
+import { Task, TaskStatus } from '../models/Task';
+import TaskModal from '../components/TaskModal';
+import { useProjects } from '../hooks/useProjects';
+import { Comment as ProjectComment } from '../models/Comment';
+
+/**
+ * いつかやる/多分やるリストページコンポーネント
+ * 
+ * 'someday-maybe'ステータスのタスクを表示するための専用ページです。
+ */
+const SomedayMaybeListPage: React.FC = () => {
+  const {
+    tasks,
+    loading: tasksLoading,
+    error: tasksError,
+    updateTask,
+    deleteTask,
+    filterCriteria,
+    setFilterCriteria,
+    sortCriteria,
+    setSortCriteria,
+    changeTaskStatus,
+  } = useTasks();
+
+  const { projects, loading: projectsLoading } = useProjects();
+
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  // コンポーネントマウント時に'someday-maybe'フィルターを適用
+  React.useEffect(() => {
+    setFilterCriteria({ ...filterCriteria, status: 'someday-maybe' });
+  }, []);
+
+  const handleEditTask = (task: Task) => {
+    setSelectedTask(task);
+    setIsEditModalVisible(true);
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    if (window.confirm('このタスクを削除してもよろしいですか？')) {
+      await deleteTask(taskId);
+    }
+  };
+
+  const handleStatusChange = async (taskId: string, status: TaskStatus) => {
+    await changeTaskStatus(taskId, status);
+  };
+
+  const handleUpdateExistingTask = async (id: string, formData: any) => {
+    const updatedTask = await updateTask(id, formData);
+    setIsEditModalVisible(false);
+    setSelectedTask(null);
+    return updatedTask;
+  };
+
+  if (tasksLoading || projectsLoading) {
+    return (
+      <ContentLayout>
+        <Spinner size="large" />
+      </ContentLayout>
+    );
+  }
+
+  if (tasksError) {
+    return (
+      <ContentLayout>
+        <Alert type="error">{tasksError}</Alert>
+      </ContentLayout>
+    );
+  }
+
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return tasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [tasks]);
+
+  return (
+    <ContentLayout header={<Header variant="h1">いつかやる/多分やるリスト</Header>}>
+      <SpaceBetween size="l">
+        <TaskList
+          tasks={tasksForTaskList}
+          loading={tasksLoading}
+          error={tasksError}
+          filterCriteria={filterCriteria as FilterCriteria}
+          setFilterCriteria={setFilterCriteria}
+          sortCriteria={sortCriteria as SortCriteria | null}
+          setSortCriteria={setSortCriteria}
+          onEditTask={handleEditTask}
+          onDeleteTask={handleDeleteTask}
+          onStatusChange={handleStatusChange}
+        />
+        {isEditModalVisible && selectedTask && (
+          <TaskModal
+            visible={isEditModalVisible}
+            onDismiss={() => {
+              setIsEditModalVisible(false);
+              setSelectedTask(null);
+            }}
+            task={selectedTask}
+            onUpdateTask={handleUpdateExistingTask}
+            onAddTask={() => Promise.resolve(null)}
+            projects={projects}
+          />
+        )}
+      </SpaceBetween>
+    </ContentLayout>
+  );
+};
+
+export default SomedayMaybeListPage;

--- a/src/pages/WaitingOnListPage.tsx
+++ b/src/pages/WaitingOnListPage.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useMemo } from 'react';
+import {
+  ContentLayout,
+  Header,
+  SpaceBetween,
+  Alert,
+  Spinner,
+} from '@cloudscape-design/components';
+import TaskList from '../components/TaskList';
+import { useTasks, FilterCriteria, SortCriteria, InternalTask } from '../hooks/useTasks';
+import { Comment as ProjectComment } from '../models/Comment';
+import { Task, TaskStatus } from '../models/Task';
+import TaskModal from '../components/TaskModal';
+import { useProjects } from '../hooks/useProjects';
+
+/**
+ * 待機中タスクリストページコンポーネント
+ * 
+ * 'wait-on'ステータスのタスクを表示するための専用ページです。
+ * 他者からの返信待ちや特定の条件が整うのを待っているタスクを管理します。
+ */
+const WaitingOnListPage: React.FC = () => {
+  const {
+    tasks,
+    loading: tasksLoading,
+    error: tasksError,
+    updateTask,
+    deleteTask,
+    filterCriteria,
+    setFilterCriteria,
+    sortCriteria,
+    setSortCriteria,
+    changeTaskStatus,
+  } = useTasks();
+
+  const { projects, loading: projectsLoading } = useProjects();
+
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  // コンポーネントマウント時に'wait-on'フィルターを適用
+  React.useEffect(() => {
+    setFilterCriteria({ ...filterCriteria, status: 'wait-on' });
+  }, []);
+
+  const handleEditTask = (task: Task) => {
+    setSelectedTask(task);
+    setIsEditModalVisible(true);
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    if (window.confirm('このタスクを削除してもよろしいですか？')) {
+      await deleteTask(taskId);
+    }
+  };
+
+  const handleStatusChange = async (taskId: string, status: TaskStatus) => {
+    await changeTaskStatus(taskId, status);
+  };
+
+  const handleUpdateExistingTask = async (id: string, formData: any) => {
+    const updatedTask = await updateTask(id, formData);
+    setIsEditModalVisible(false);
+    setSelectedTask(null);
+    return updatedTask;
+  };
+
+  if (tasksLoading || projectsLoading) {
+    return (
+      <ContentLayout>
+        <Spinner size="large" />
+      </ContentLayout>
+    );
+  }
+
+  if (tasksError) {
+    return (
+      <ContentLayout>
+        <Alert type="error">{tasksError}</Alert>
+      </ContentLayout>
+    );
+  }
+
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return tasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [tasks]);
+
+  return (
+    <ContentLayout header={<Header variant="h1">待機中タスク</Header>}>
+      <SpaceBetween size="l">
+        <TaskList
+          tasks={tasksForTaskList}
+          loading={tasksLoading}
+          error={tasksError}
+          filterCriteria={filterCriteria as FilterCriteria}
+          setFilterCriteria={setFilterCriteria}
+          sortCriteria={sortCriteria as SortCriteria | null}
+          setSortCriteria={setSortCriteria}
+          onEditTask={handleEditTask}
+          onDeleteTask={handleDeleteTask}
+          onStatusChange={handleStatusChange}
+        />
+        {isEditModalVisible && selectedTask && (
+          <TaskModal
+            visible={isEditModalVisible}
+            onDismiss={() => {
+              setIsEditModalVisible(false);
+              setSelectedTask(null);
+            }}
+            task={selectedTask}
+            onUpdateTask={handleUpdateExistingTask}
+            onAddTask={() => Promise.resolve(null)}
+            projects={projects}
+          />
+        )}
+      </SpaceBetween>
+    </ContentLayout>
+  );
+};
+
+export default WaitingOnListPage;


### PR DESCRIPTION
## 概要
Issue #54「タスク6 (オプション): 関連リストUIの調整」の実装を行いました。GTD処理フローの導入により追加された新しいメモのステータス（`'someday-maybe'`, `'reference'`）や、変更された既存ステータス（`'wait-on'`, `'inbox'`）のメモが、それぞれの専用リストで正しく表示されるように、関連するリスト表示コンポーネントを調整しました。

## 変更内容
1. **新しいステータス専用のページコンポーネントを作成**
   - `InboxListPage.tsx` - インボックス内のタスク管理用
   - `WaitingOnListPage.tsx` - 待機中タスクの管理用
   - `SomedayMaybeListPage.tsx` - 「いつかやる/多分やる」タスク管理用
   - `ReferenceListPage.tsx` - 参照資料として保存されたタスク管理用

2. **アプリケーションのナビゲーションを更新**
   - サイドナビゲーションに新しいページへのリンクを追加
   - ルーティング設定を更新して新しいページへのアクセスを可能に

3. **設計書の更新**
   - 新しいタスクステータス値を反映
   - ナビゲーション構造の更新を反映
   - GTDフロー関連ページの説明を追加

## 動作確認
- 各ステータス専用ページが正しく表示されることを確認
- 各ページでタスクのフィルタリングが正しく機能することを確認
- タスクの編集・削除・ステータス変更が正しく動作することを確認

## 関連Issue
Closes #54