### PR TITLE
React Hooksの条件付き呼び出しを修正 (Issue #63)

### DIFF
--- a/src/pages/InboxListPage.tsx
+++ b/src/pages/InboxListPage.tsx
@@ -41,6 +41,25 @@ const InboxListPage: React.FC = () => {
   const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return tasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [tasks]);
+
   // コンポーネントマウント時に'inbox'フィルターを適用
   React.useEffect(() => {
     setFilterCriteria({ ...filterCriteria, status: 'inbox' });
@@ -96,25 +115,6 @@ const InboxListPage: React.FC = () => {
       </ContentLayout>
     );
   }
-
-  // InternalTask[] から Task[] への変換
-  const tasksForTaskList = useMemo(() => {
-    return tasks.map((internalTask: InternalTask): Task => {
-      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
-        ...comment,
-        createdAt: comment.createdAt.toISOString(),
-        updatedAt: comment.updatedAt?.toISOString(), 
-      }));
-
-      return {
-        ...internalTask,
-        createdAt: internalTask.createdAt.toISOString(),
-        updatedAt: internalTask.updatedAt.toISOString(),
-        dueDate: internalTask.dueDate?.toISOString(),
-        comments: commentsForTask, 
-      };
-    });
-  }, [tasks]);
 
   return (
     <ContentLayout header={<Header variant="h1">インボックス</Header>}>

--- a/src/pages/ReferenceListPage.tsx
+++ b/src/pages/ReferenceListPage.tsx
@@ -37,6 +37,25 @@ const ReferenceListPage: React.FC = () => {
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return tasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [tasks]);
+
   // コンポーネントマウント時に'reference'フィルターを適用
   React.useEffect(() => {
     setFilterCriteria({ ...filterCriteria, status: 'reference' });
@@ -79,25 +98,6 @@ const ReferenceListPage: React.FC = () => {
       </ContentLayout>
     );
   }
-
-  // InternalTask[] から Task[] への変換
-  const tasksForTaskList = useMemo(() => {
-    return tasks.map((internalTask: InternalTask): Task => {
-      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
-        ...comment,
-        createdAt: comment.createdAt.toISOString(),
-        updatedAt: comment.updatedAt?.toISOString(), 
-      }));
-
-      return {
-        ...internalTask,
-        createdAt: internalTask.createdAt.toISOString(),
-        updatedAt: internalTask.updatedAt.toISOString(),
-        dueDate: internalTask.dueDate?.toISOString(),
-        comments: commentsForTask, 
-      };
-    });
-  }, [tasks]);
 
   return (
     <ContentLayout header={<Header variant="h1">資料リスト</Header>}>

--- a/src/pages/SomedayMaybeListPage.tsx
+++ b/src/pages/SomedayMaybeListPage.tsx
@@ -37,6 +37,25 @@ const SomedayMaybeListPage: React.FC = () => {
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return tasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [tasks]);
+
   // コンポーネントマウント時に'someday-maybe'フィルターを適用
   React.useEffect(() => {
     setFilterCriteria({ ...filterCriteria, status: 'someday-maybe' });
@@ -79,25 +98,6 @@ const SomedayMaybeListPage: React.FC = () => {
       </ContentLayout>
     );
   }
-
-  // InternalTask[] から Task[] への変換
-  const tasksForTaskList = useMemo(() => {
-    return tasks.map((internalTask: InternalTask): Task => {
-      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
-        ...comment,
-        createdAt: comment.createdAt.toISOString(),
-        updatedAt: comment.updatedAt?.toISOString(), 
-      }));
-
-      return {
-        ...internalTask,
-        createdAt: internalTask.createdAt.toISOString(),
-        updatedAt: internalTask.updatedAt.toISOString(),
-        dueDate: internalTask.dueDate?.toISOString(),
-        comments: commentsForTask, 
-      };
-    });
-  }, [tasks]);
 
   return (
     <ContentLayout header={<Header variant="h1">いつかやる/多分やるリスト</Header>}>

--- a/src/pages/WaitingOnListPage.tsx
+++ b/src/pages/WaitingOnListPage.tsx
@@ -38,6 +38,25 @@ const WaitingOnListPage: React.FC = () => {
   const [isEditModalVisible, setIsEditModalVisible] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return tasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [tasks]);
+
   // コンポーネントマウント時に'wait-on'フィルターを適用
   React.useEffect(() => {
     setFilterCriteria({ ...filterCriteria, status: 'wait-on' });
@@ -80,25 +99,6 @@ const WaitingOnListPage: React.FC = () => {
       </ContentLayout>
     );
   }
-
-  // InternalTask[] から Task[] への変換
-  const tasksForTaskList = useMemo(() => {
-    return tasks.map((internalTask: InternalTask): Task => {
-      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
-        ...comment,
-        createdAt: comment.createdAt.toISOString(),
-        updatedAt: comment.updatedAt?.toISOString(), 
-      }));
-
-      return {
-        ...internalTask,
-        createdAt: internalTask.createdAt.toISOString(),
-        updatedAt: internalTask.updatedAt.toISOString(),
-        dueDate: internalTask.dueDate?.toISOString(),
-        comments: commentsForTask, 
-      };
-    });
-  }, [tasks]);
 
   return (
     <ContentLayout header={<Header variant="h1">待機中タスク</Header>}>


### PR DESCRIPTION
## 概要
Issue #63で報告されたESLintエラーを修正しました。具体的には、各ページコンポーネントで`useMemo`フックが条件分岐の後に呼び出されていたため、これをコンポーネントの先頭部分に移動しました。

## 変更内容
以下のファイルで、`useMemo`フックをコンポーネントの先頭部分に移動し、条件付き呼び出しを避けるように修正しました：
- `src/pages/InboxListPage.tsx`
- `src/pages/ReferenceListPage.tsx`
- `src/pages/SomedayMaybeListPage.tsx`
- `src/pages/WaitingOnListPage.tsx`

## 修正方針
React Hooksのルールに従い、Hooksは常に同じ順序で呼び出されるように修正しました。具体的には、`useMemo`フックを条件分岐（early return）の前に移動し、コンポーネントの先頭部分で呼び出すようにしました。

## 関連Issue
Closes #63