### PR TITLE
feat: Inbox専用ビューの実装 #65

### DIFF
--- a/documents/design.md
+++ b/documents/design.md
@@ -372,7 +372,10 @@ interface Project {
 
 -   GTDフローの導入により、新しいステータス値 (`'someday-maybe'`, `'reference'`) に対応する専用ページが追加されました。
 -   各ステータス専用のページコンポーネント:
-    -   `InboxListPage.tsx`: インボックス内のタスクを表示・管理するページ (`/inbox`)
+    -   `InboxListPage.tsx`: インボックス内のタスクを表示・管理するページ (`/inbox`)。以下の機能を提供します：
+        -   コンポーネントマウント時に'inbox'ステータスのタスクのみをフィルタリングして表示
+        -   新規タスク追加時にステータスを強制的に'inbox'に設定
+        -   クイック追加機能（AddTaskButton）との連携により、新しいタスクをすぐにInboxに追加可能
     -   `WaitingOnListPage.tsx`: 待機中（他者からの返信待ちなど）のタスクを表示・管理するページ (`/waiting-on`)
     -   `SomedayMaybeListPage.tsx`: 「いつかやる/多分やる」タスクを表示・管理するページ (`/someday-maybe`)
     -   `ReferenceListPage.tsx`: 参照資料として保存されたタスクを表示・管理するページ (`/reference`)


### PR DESCRIPTION
## 概要
Issue #65「Inbox専用ビューの実装」に対応しました。

## 変更内容
調査の結果、Inbox専用ビューは既に以下の機能を含めて実装されていることを確認しました：

1. `InboxListPage.tsx`が実装されており、以下の機能が含まれています：
   - コンポーネントマウント時に'inbox'フィルターを適用
   - 新規タスク追加時にステータスを強制的に'inbox'に設定
   - AddTaskButtonコンポーネントの配置

2. `App.tsx`にはInboxビュー用のルート（`/inbox`）が設定されており、ナビゲーションメニューにも「インボックス」項目が存在します。

設計書（documents/design.md）を更新し、InboxListPage.tsxの機能説明を拡充しました。

## 関連Issue
Closes #65