### PR TITLE
feat: GTDワークフローに基づいた包括的なサイドナビゲーション構造の実装 #79

### DIFF
--- a/src/pages/CompletedTasksPage.tsx
+++ b/src/pages/CompletedTasksPage.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import {
+  ContentLayout,
+  Header,
+  SpaceBetween,
+  Alert,
+  Spinner,
+} from '@cloudscape-design/components';
+import TaskList from '../components/TaskList';
+import { useTasks, FilterCriteria, SortCriteria, InternalTask } from '../hooks/useTasks';
+import { Comment as ProjectComment } from '../models/Comment';
+import { Task, TaskStatus } from '../models/Task';
+import TaskModal from '../components/TaskModal';
+import { useProjects } from '../hooks/useProjects';
+
+/**
+ * 完了済みタスクページコンポーネント
+ * 
+ * 'done'ステータスのタスクを表示するための専用ページです。
+ * GTDメソッドの「レビュー」フェーズに対応し、完了したタスクを確認できます。
+ */
+const CompletedTasksPage: React.FC = () => {
+  const {
+    tasks,
+    loading: tasksLoading,
+    error: tasksError,
+    updateTask,
+    deleteTask,
+    filterCriteria,
+    setFilterCriteria,
+    sortCriteria,
+    setSortCriteria,
+    changeTaskStatus,
+  } = useTasks();
+
+  const { projects, loading: projectsLoading } = useProjects();
+
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  // コンポーネントマウント時に'done'フィルターを適用
+  useEffect(() => {
+    setFilterCriteria({ ...filterCriteria, status: 'done' });
+    // 更新日時の降順でソート（デフォルト）
+    setSortCriteria({ field: 'updatedAt', direction: 'desc' });
+  }, []);
+
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return tasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [tasks]);
+
+  const handleEditTask = (task: Task) => {
+    setSelectedTask(task);
+    setIsEditModalVisible(true);
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    if (window.confirm('このタスクを削除してもよろしいですか？')) {
+      await deleteTask(taskId);
+    }
+  };
+
+  const handleStatusChange = async (taskId: string, status: TaskStatus) => {
+    await changeTaskStatus(taskId, status);
+  };
+
+  const handleUpdateExistingTask = async (id: string, formData: any) => {
+    const updatedTask = await updateTask(id, formData);
+    setIsEditModalVisible(false);
+    setSelectedTask(null);
+    return updatedTask;
+  };
+
+  if (tasksLoading || projectsLoading) {
+    return (
+      <ContentLayout>
+        <Spinner size="large" />
+      </ContentLayout>
+    );
+  }
+
+  if (tasksError) {
+    return (
+      <ContentLayout>
+        <Alert type="error">{tasksError}</Alert>
+      </ContentLayout>
+    );
+  }
+
+  return (
+    <ContentLayout header={<Header variant="h1">完了済みタスク</Header>}>
+      <SpaceBetween size="l">
+        <TaskList
+          tasks={tasksForTaskList}
+          loading={tasksLoading}
+          error={tasksError}
+          filterCriteria={filterCriteria as FilterCriteria}
+          setFilterCriteria={setFilterCriteria}
+          sortCriteria={sortCriteria as SortCriteria | null}
+          setSortCriteria={setSortCriteria}
+          onEditTask={handleEditTask}
+          onDeleteTask={handleDeleteTask}
+          onStatusChange={handleStatusChange}
+        />
+        {isEditModalVisible && (
+          <TaskModal
+            visible={isEditModalVisible}
+            onDismiss={() => {
+              setIsEditModalVisible(false);
+              setSelectedTask(null);
+            }}
+            task={selectedTask || undefined}
+            onUpdateTask={handleUpdateExistingTask}
+            onAddTask={() => Promise.resolve(null)} // 完了済みページでは新規追加は不要
+            projects={projects}
+          />
+        )}
+      </SpaceBetween>
+    </ContentLayout>
+  );
+};
+
+export default CompletedTasksPage;

--- a/src/pages/NextActionsPage.tsx
+++ b/src/pages/NextActionsPage.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import {
+  ContentLayout,
+  Header,
+  SpaceBetween,
+  Alert,
+  Spinner,
+} from '@cloudscape-design/components';
+import TaskList from '../components/TaskList';
+import { useTasks, FilterCriteria, SortCriteria, InternalTask } from '../hooks/useTasks';
+import { Comment as ProjectComment } from '../models/Comment';
+import { Task, TaskStatus } from '../models/Task';
+import TaskModal from '../components/TaskModal';
+import { useProjects } from '../hooks/useProjects';
+import { AddTaskButton } from '../components/AddTaskButton';
+
+/**
+ * 次のアクションページコンポーネント
+ * 
+ * 'todo'ステータスかつ'nextAction'フラグがtrueのタスクを表示するための専用ページです。
+ * GTDメソッドの「整理」フェーズで特定された、次に取り組むべき具体的なアクションを一覧表示します。
+ */
+const NextActionsPage: React.FC = () => {
+  const {
+    tasks,
+    loading: tasksLoading,
+    error: tasksError,
+    updateTask,
+    deleteTask,
+    addTask,
+    filterCriteria,
+    setFilterCriteria,
+    sortCriteria,
+    setSortCriteria,
+    changeTaskStatus,
+  } = useTasks();
+
+  const { projects, loading: projectsLoading } = useProjects();
+
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+  const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  // 次のアクションタスクのみをフィルタリング
+  const nextActionTasks = useMemo(() => {
+    return tasks.filter(task => task.status === 'todo' && task.nextAction === true);
+  }, [tasks]);
+
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return nextActionTasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [nextActionTasks]);
+
+  const handleOpenCreateModal = () => {
+    setSelectedTask(null);
+    setIsCreateModalVisible(true);
+  };
+
+  const handleEditTask = (task: Task) => {
+    setSelectedTask(task);
+    setIsEditModalVisible(true);
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    if (window.confirm('このタスクを削除してもよろしいですか？')) {
+      await deleteTask(taskId);
+    }
+  };
+
+  const handleStatusChange = async (taskId: string, status: TaskStatus) => {
+    await changeTaskStatus(taskId, status);
+  };
+
+  const handleUpdateExistingTask = async (id: string, formData: any) => {
+    const updatedTask = await updateTask(id, formData);
+    setIsEditModalVisible(false);
+    setSelectedTask(null);
+    return updatedTask;
+  };
+
+  const handleAddNewTask = async (formData: any) => {
+    // 次のアクションとして追加する場合はステータスを'todo'に設定し、nextActionフラグをtrueに設定
+    const taskData = { ...formData, status: 'todo', nextAction: true };
+    const newTask = await addTask(taskData);
+    setIsCreateModalVisible(false);
+    return newTask;
+  };
+
+  if (tasksLoading || projectsLoading) {
+    return (
+      <ContentLayout>
+        <Spinner size="large" />
+      </ContentLayout>
+    );
+  }
+
+  if (tasksError) {
+    return (
+      <ContentLayout>
+        <Alert type="error">{tasksError}</Alert>
+      </ContentLayout>
+    );
+  }
+
+  return (
+    <ContentLayout header={<Header variant="h1">次のアクション</Header>}>
+      <SpaceBetween size="l">
+        <AddTaskButton onClick={handleOpenCreateModal} />
+        <TaskList
+          tasks={tasksForTaskList}
+          loading={tasksLoading}
+          error={tasksError}
+          filterCriteria={filterCriteria as FilterCriteria}
+          setFilterCriteria={setFilterCriteria}
+          sortCriteria={sortCriteria as SortCriteria | null}
+          setSortCriteria={setSortCriteria}
+          onEditTask={handleEditTask}
+          onDeleteTask={handleDeleteTask}
+          onStatusChange={handleStatusChange}
+        />
+        {(isEditModalVisible || isCreateModalVisible) && (
+          <TaskModal
+            visible={isEditModalVisible || isCreateModalVisible}
+            onDismiss={() => {
+              setIsEditModalVisible(false);
+              setIsCreateModalVisible(false);
+              setSelectedTask(null);
+            }}
+            task={selectedTask || undefined}
+            onUpdateTask={handleUpdateExistingTask}
+            onAddTask={handleAddNewTask}
+            projects={projects}
+          />
+        )}
+      </SpaceBetween>
+    </ContentLayout>
+  );
+};
+
+export default NextActionsPage;

--- a/src/pages/ScheduledTasksPage.tsx
+++ b/src/pages/ScheduledTasksPage.tsx
@@ -1,0 +1,163 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import {
+  ContentLayout,
+  Header,
+  SpaceBetween,
+  Alert,
+  Spinner,
+} from '@cloudscape-design/components';
+import TaskList from '../components/TaskList';
+import { useTasks, FilterCriteria, SortCriteria, InternalTask } from '../hooks/useTasks';
+import { Comment as ProjectComment } from '../models/Comment';
+import { Task, TaskStatus } from '../models/Task';
+import TaskModal from '../components/TaskModal';
+import { useProjects } from '../hooks/useProjects';
+import { AddTaskButton } from '../components/AddTaskButton';
+
+/**
+ * 予定済みタスクページコンポーネント
+ * 
+ * 'todo'ステータスかつ期限日(dueDate)が設定されているタスクを表示するための専用ページです。
+ * GTDメソッドの「整理」フェーズで特定された、特定の日時が決まっているタスクを一覧表示します。
+ */
+const ScheduledTasksPage: React.FC = () => {
+  const {
+    tasks,
+    loading: tasksLoading,
+    error: tasksError,
+    updateTask,
+    deleteTask,
+    addTask,
+    filterCriteria,
+    setFilterCriteria,
+    sortCriteria,
+    setSortCriteria,
+    changeTaskStatus,
+  } = useTasks();
+
+  const { projects, loading: projectsLoading } = useProjects();
+
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+  const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  // 予定済みタスクのみをフィルタリング
+  const scheduledTasks = useMemo(() => {
+    return tasks.filter(task => task.status === 'todo' && task.dueDate !== undefined && task.dueDate !== null);
+  }, [tasks]);
+
+  // InternalTask[] から Task[] への変換
+  const tasksForTaskList = useMemo(() => {
+    return scheduledTasks.map((internalTask: InternalTask): Task => {
+      const commentsForTask: ProjectComment[] | undefined = internalTask.comments?.map(comment => ({
+        ...comment,
+        createdAt: comment.createdAt.toISOString(),
+        updatedAt: comment.updatedAt?.toISOString(), 
+      }));
+
+      return {
+        ...internalTask,
+        createdAt: internalTask.createdAt.toISOString(),
+        updatedAt: internalTask.updatedAt.toISOString(),
+        dueDate: internalTask.dueDate?.toISOString(),
+        comments: commentsForTask, 
+      };
+    });
+  }, [scheduledTasks]);
+
+  // 期限日でソート（デフォルト）
+  useEffect(() => {
+    setSortCriteria({ field: 'dueDate', direction: 'asc' });
+  }, []);
+
+  const handleOpenCreateModal = () => {
+    setSelectedTask(null);
+    setIsCreateModalVisible(true);
+  };
+
+  const handleEditTask = (task: Task) => {
+    setSelectedTask(task);
+    setIsEditModalVisible(true);
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    if (window.confirm('このタスクを削除してもよろしいですか？')) {
+      await deleteTask(taskId);
+    }
+  };
+
+  const handleStatusChange = async (taskId: string, status: TaskStatus) => {
+    await changeTaskStatus(taskId, status);
+  };
+
+  const handleUpdateExistingTask = async (id: string, formData: any) => {
+    const updatedTask = await updateTask(id, formData);
+    setIsEditModalVisible(false);
+    setSelectedTask(null);
+    return updatedTask;
+  };
+
+  const handleAddNewTask = async (formData: any) => {
+    // 予定済みタスクとして追加する場合はステータスを'todo'に設定し、期限日が必須
+    if (!formData.dueDate) {
+      alert('予定済みタスクには期限日の設定が必要です');
+      return null;
+    }
+    const taskData = { ...formData, status: 'todo' };
+    const newTask = await addTask(taskData);
+    setIsCreateModalVisible(false);
+    return newTask;
+  };
+
+  if (tasksLoading || projectsLoading) {
+    return (
+      <ContentLayout>
+        <Spinner size="large" />
+      </ContentLayout>
+    );
+  }
+
+  if (tasksError) {
+    return (
+      <ContentLayout>
+        <Alert type="error">{tasksError}</Alert>
+      </ContentLayout>
+    );
+  }
+
+  return (
+    <ContentLayout header={<Header variant="h1">予定済みタスク</Header>}>
+      <SpaceBetween size="l">
+        <AddTaskButton onClick={handleOpenCreateModal} />
+        <TaskList
+          tasks={tasksForTaskList}
+          loading={tasksLoading}
+          error={tasksError}
+          filterCriteria={filterCriteria as FilterCriteria}
+          setFilterCriteria={setFilterCriteria}
+          sortCriteria={sortCriteria as SortCriteria | null}
+          setSortCriteria={setSortCriteria}
+          onEditTask={handleEditTask}
+          onDeleteTask={handleDeleteTask}
+          onStatusChange={handleStatusChange}
+        />
+        {(isEditModalVisible || isCreateModalVisible) && (
+          <TaskModal
+            visible={isEditModalVisible || isCreateModalVisible}
+            onDismiss={() => {
+              setIsEditModalVisible(false);
+              setIsCreateModalVisible(false);
+              setSelectedTask(null);
+            }}
+            task={selectedTask || undefined}
+            onUpdateTask={handleUpdateExistingTask}
+            onAddTask={handleAddNewTask}
+            projects={projects}
+          />
+        )}
+      </SpaceBetween>
+    </ContentLayout>
+  );
+};
+
+export default ScheduledTasksPage;


### PR DESCRIPTION
## 概要
Issue #79 に対応し、GTDワークフローに基づいた包括的なサイドナビゲーション構造を実装しました。

## 変更内容
- サイドナビゲーションをGTDワークフローの各フェーズ（収集、処理・整理、参照、レビュー）に基づいて再構成
- 各カテゴリのタスク数をバッジで表示する機能を追加
- 新しいページコンポーネントを追加
  - `NextActionsPage.tsx`: 次のアクション（`nextAction`フラグがtrueのタスク）を表示
  - `ScheduledTasksPage.tsx`: 予定済みタスク（期限日が設定されているタスク）を表示
  - `CompletedTasksPage.tsx`: 完了済みタスク（`done`ステータスのタスク）を表示

## テスト内容
- 各ナビゲーション項目がクリックで対応するビューに遷移することを確認
- 現在のビューがハイライト表示されることを確認
- 各カテゴリのタスク数が正しくバッジに表示されることを確認
- 新しく追加したページが正しく表示・機能することを確認

## 関連Issue
Closes #79